### PR TITLE
Fix Unicode in PDF chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ packages from `requirements.txt`.
 source .venv/bin/activate
 ```
 
-Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, which now embeds the DejaVuSans TrueType font so that Unicode characters render correctly (no LaTeX engine required). Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
+Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, which embeds the DejaVuSans TrueType font so that Unicode characters render correctly (no LaTeX engine required). The chunking step uses the same font to avoid encoding errors. Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
 
 ## Usage
 

--- a/orchestrate_all.py
+++ b/orchestrate_all.py
@@ -160,7 +160,13 @@ def chunk_pdf(pdf_path: Path, base_name: str) -> None:
         pdf = FPDF()
         pdf.add_page()
         pdf.set_auto_page_break(True, margin=15)
-        pdf.set_font("Arial", size=12)
+        pdf.add_font(
+            "DejaVu",
+            "",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            uni=True,
+        )
+        pdf.set_font("DejaVu", size=12)
         pdf.multi_cell(0, 10, chunk_text)
         out_path = CHUNK_DIR / f"{base_name}_{chunk_idx:03d}.pdf"
         pdf.output(str(out_path))


### PR DESCRIPTION
## Summary
- ensure `orchestrate_all.py` uses a Unicode-capable font when creating chunk PDFs
- mention font reuse in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be256fc1c8332b1edd25ebac5b585