### PR TITLE
Add pipefail strictness to merge script

### DIFF
--- a/merge.sh
+++ b/merge.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 INGEST_DIR="./Ingest"
 MERGED_DIR="./Merged"


### PR DESCRIPTION
## Summary
- enforce stricter shell options in `merge.sh`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf4b160448332b6969ac163fa901e