### PR TITLE
Add configurable font path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ packages from `requirements.txt`.
 source .venv/bin/activate
 ```
 
-Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, which embeds the DejaVuSans TrueType font so that Unicode characters render correctly (no LaTeX engine required). The chunking step uses the same font to avoid encoding errors. Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
+Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, which embeds the DejaVuSans TrueType font so that Unicode characters render correctly (no LaTeX engine required). The chunking step uses the same font to avoid encoding errors. Optionally set the environment variables `KB_DIR` to point to your knowledge base and `FONT_PATH` to override the font used when generating PDFs. `FONT_PATH` defaults to `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` while `KB_DIR` defaults to `/home/cinder/Documents/K_Knowledge_Base`.
 
 ## Usage
 

--- a/orchestrate_all.py
+++ b/orchestrate_all.py
@@ -12,6 +12,13 @@ except ModuleNotFoundError:  # fall back for environments with PyPDF2 installed
     from PyPDF2 import PdfMerger, PdfReader
 from fpdf import FPDF
 
+FONT_PATH = Path(
+    os.environ.get(
+        "FONT_PATH",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    )
+)
+
 
 def markdown_to_pdf(src: Path, dest: Path) -> None:
     """Render a Markdown file to PDF using FPDF.
@@ -29,7 +36,7 @@ def markdown_to_pdf(src: Path, dest: Path) -> None:
     pdf.add_font(
         "DejaVu",
         "",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        str(FONT_PATH),
         uni=True,
     )
     pdf.set_font("DejaVu", size=12)
@@ -207,7 +214,7 @@ def chunk_pdf(pdf_path: Path, base_name: str) -> None:
         pdf.add_font(
             "DejaVu",
             "",
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            str(FONT_PATH),
             uni=True,
         )
         pdf.set_font("DejaVu", size=12)


### PR DESCRIPTION
## Summary
- allow overriding font path via `FONT_PATH` environment variable
- respect `FONT_PATH` in PDF generation
- document the variable in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf4b4d5748332ad5a775dbd0d0e04