### PR TITLE
Fix convert_to_kindle.sh strict mode

### DIFF
--- a/convert_to_kindle.sh
+++ b/convert_to_kindle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Use BASE_DIR if provided, otherwise default to the current directory
 BASE_DIR="${BASE_DIR:-$(pwd)}"


### PR DESCRIPTION
## Summary
- enable strict error handling in `convert_to_kindle.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bf4b988d48332a356e4c2880ef663